### PR TITLE
Feat/27-Analytics-set

### DIFF
--- a/src/app/ga-tracker.tsx
+++ b/src/app/ga-tracker.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { sendPageView } from '@/lib/analytics/ga';
+
+export default function GaTracker() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const q = searchParams?.toString();
+    const path = q ? `${pathname}?${q}` : pathname;
+    sendPageView(path);
+  }, [pathname, searchParams]);
+
+  return null;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import Script from 'next/script';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
 import Providers from '@/app/providers';
+import GaTracker from '@/app/ga-tracker';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -25,10 +26,13 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   const beaconToken = process.env.NEXT_PUBLIC_CF_BEACON_TOKEN;
+  const gaId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+  const gaEnabled = process.env.NODE_ENV === 'production' && !!gaId && process.env.NEXT_PUBLIC_ENABLE_GA !== 'false';
   return (
     <html lang="ko">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <Providers>{children}</Providers>
+
         {/* Cloudflare Web Analytics (JS Beacon) */}
         {process.env.NODE_ENV === 'production' && beaconToken ? (
           <Script
@@ -38,6 +42,27 @@ export default function RootLayout({
             // SPA 라우팅 자동 추적 켜기(spa: true).
             data-cf-beacon={JSON.stringify({ token: beaconToken, spa: true })}
           />
+        ) : null}
+
+        {/* GA4 (프로덕션 & 활성화 시에만 로드) */}
+        {gaEnabled ? (
+          <>
+            <Script
+              id="ga4-src"
+              src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
+              strategy="afterInteractive"
+            />
+            <Script id="ga4-init" strategy="afterInteractive">
+              {`
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                // SPA는 자동 page_view 비활성화 후 라우트 변경 때 수동 전송
+                gtag('config', '${gaId}', { send_page_view: false });
+              `}
+            </Script>
+            <GaTracker />
+          </>
         ) : null}
       </body>
     </html>

--- a/src/lib/analytics/enents.ts
+++ b/src/lib/analytics/enents.ts
@@ -1,0 +1,22 @@
+// src/lib/analytics/events.ts
+import { sendGaEvent } from './ga';
+
+export function trackClickChannel(params: {
+  channel_id: string;
+  platform: 'youtube' | 'chzzk';
+  location: 'sidebar' | 'grid' | 'feed';
+}) {
+  sendGaEvent('click_channel', params);
+}
+
+export function trackChangeTab(params: { tab: 'all' | 'youtube' | 'chzzk' }) {
+  sendGaEvent('change_tab', params);
+}
+
+export function trackApplyFilter(params: { filter: string; value?: string }) {
+  sendGaEvent('apply_filter', params);
+}
+
+export function trackRefreshFeed(params?: { scope?: 'creator' | 'all' }) {
+  sendGaEvent('refresh_feed', params);
+}

--- a/src/lib/analytics/ga.ts
+++ b/src/lib/analytics/ga.ts
@@ -1,0 +1,22 @@
+// src/lib/analytics/ga.ts
+export function getGaId(): string | undefined {
+  return process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+}
+
+export function isGaEnabled(): boolean {
+  return process.env.NODE_ENV === 'production' && !!process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+}
+
+export function sendGaEvent(name: string, params?: Record<string, unknown>) {
+  if (typeof window === 'undefined' || !isGaEnabled()) return;
+  (window as any).gtag?.('event', name, params ?? {});
+}
+
+export function sendPageView(path: string) {
+  if (typeof window === 'undefined' || !isGaEnabled()) return;
+  (window as any).gtag?.('event', 'page_view', {
+    page_location: window.location.href,
+    page_path: path,
+    page_title: document.title,
+  });
+}


### PR DESCRIPTION
•	Next.js 레이아웃에 GaTracker 연동하여 page_view 자동 전송
	•	GA 헬퍼 추가: 프로덕션+NEXT_PUBLIC_GA_MEASUREMENT_ID 설정 시에만 로드
	•	중복 집계 방지: GA 기본 스니펫 미사용 전제(커스텀 트래커만 사용)

[💫 feat]  웹사이트 방문 통계 시스템 구축 (GA4, Cloudflare)
Fixes #27

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
