### PR TITLE
fix: 현재 Image Optimization - Transformations 사용량 초과로 인한 이미지최적화 제거

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,7 @@ const nextConfig: NextConfig = {
   },
   allowedDevOrigins: ['calm-stinkbug-pure.ngrok-free.app'],
   images: {
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: 'https',


### PR DESCRIPTION
- vercel에 hobby플랜의 이미지 사용량 초과로 최적화 제거
